### PR TITLE
Replace RxJava dependency by new class ExceptionHelper

### DIFF
--- a/openpdf/pom.xml
+++ b/openpdf/pom.xml
@@ -13,7 +13,6 @@
 
     <properties>
         <bouncycastle.version>1.60</bouncycastle.version>
-        <rxjava.version>2.2.0</rxjava.version>
         <commons-text.version>1.3</commons-text.version>
         <commons-compress.version>1.17</commons-compress.version>
         <commons-io.version>2.6</commons-io.version>
@@ -40,11 +39,6 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
             <version>${commons-text.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.reactivex.rxjava2</groupId>
-            <artifactId>rxjava</artifactId>
-            <version>${rxjava.version}</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/openpdf/src/main/java/com/lowagie/bouncycastle/BouncyCastleHelper.java
+++ b/openpdf/src/main/java/com/lowagie/bouncycastle/BouncyCastleHelper.java
@@ -2,7 +2,7 @@ package com.lowagie.bouncycastle;
 
 import com.lowagie.text.pdf.PdfArray;
 import com.lowagie.text.pdf.PdfObject;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cms.CMSEnvelopedData;
 import org.bouncycastle.cms.Recipient;
@@ -23,7 +23,7 @@ public class BouncyCastleHelper {
         try {
             X509CertificateHolder certificateHolder = new X509CertificateHolder(certificate.getEncoded());
         } catch (CertificateEncodingException | IOException f) {
-            throw ExceptionHelper.wrapOrThrow(f);
+            throw ExceptionHelper.convertToRuntimeException(f);
         }
         // ******************************************************************************
     }
@@ -50,7 +50,7 @@ public class BouncyCastleHelper {
 
                 }
             } catch (Exception f) {
-                throw ExceptionHelper.wrapOrThrow(f);
+                throw ExceptionHelper.convertToRuntimeException(f);
             }
         }
         return envelopedData;

--- a/openpdf/src/main/java/com/lowagie/text/DocWriter.java
+++ b/openpdf/src/main/java/com/lowagie/text/DocWriter.java
@@ -56,7 +56,7 @@ import java.util.Iterator;
 import java.util.Properties;
 
 import com.lowagie.text.pdf.OutputStreamCounter;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 
 /**
  * An abstract <CODE>Writer</CODE> class for documents.
@@ -287,7 +287,7 @@ public abstract class DocWriter implements DocListener {
                 os.close();
         }
         catch(IOException ioe) {
-            throw ExceptionHelper.wrapOrThrow(ioe);
+            throw ExceptionHelper.convertToRuntimeException(ioe);
         }
     }
 
@@ -345,7 +345,7 @@ public abstract class DocWriter implements DocListener {
             os.flush();
         }
         catch(IOException ioe) {
-            throw ExceptionHelper.wrapOrThrow(ioe);
+            throw ExceptionHelper.convertToRuntimeException(ioe);
         }
     }
 

--- a/openpdf/src/main/java/com/lowagie/text/Document.java
+++ b/openpdf/src/main/java/com/lowagie/text/Document.java
@@ -55,7 +55,7 @@ import java.util.Date;
 import java.util.List;
 
 import com.lowagie.text.error_messages.MessageLocalization;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 
 /**
  * A generic Document class.
@@ -468,7 +468,7 @@ public class Document implements DocListener {
         try {
             return add(new Header(name, content));
 		} catch (DocumentException de) {
-            throw ExceptionHelper.wrapOrThrow(de);
+            throw ExceptionHelper.convertToRuntimeException(de);
         }
     }
     
@@ -484,7 +484,7 @@ public class Document implements DocListener {
         try {
             return add(new Meta(Element.TITLE, title));
 		} catch (DocumentException de) {
-            throw ExceptionHelper.wrapOrThrow(de);
+            throw ExceptionHelper.convertToRuntimeException(de);
         }
     }
     
@@ -500,7 +500,7 @@ public class Document implements DocListener {
         try {
             return add(new Meta(Element.SUBJECT, subject));
 		} catch (DocumentException de) {
-            throw ExceptionHelper.wrapOrThrow(de);
+            throw ExceptionHelper.convertToRuntimeException(de);
         }
     }
     
@@ -516,7 +516,7 @@ public class Document implements DocListener {
         try {
             return add(new Meta(Element.KEYWORDS, keywords));
 		} catch (DocumentException de) {
-            throw ExceptionHelper.wrapOrThrow(de);
+            throw ExceptionHelper.convertToRuntimeException(de);
         }
     }
     
@@ -532,7 +532,7 @@ public class Document implements DocListener {
         try {
             return add(new Meta(Element.AUTHOR, author));
 		} catch (DocumentException de) {
-            throw ExceptionHelper.wrapOrThrow(de);
+            throw ExceptionHelper.convertToRuntimeException(de);
         }
     }
     
@@ -548,7 +548,7 @@ public class Document implements DocListener {
         try {
             return add(new Meta(Element.CREATOR, creator));
 		} catch (DocumentException de) {
-            throw ExceptionHelper.wrapOrThrow(de);
+            throw ExceptionHelper.convertToRuntimeException(de);
         }
     }
     
@@ -562,7 +562,7 @@ public class Document implements DocListener {
         try {
             return add(new Meta(Element.PRODUCER, getVersion()));
 		} catch (DocumentException de) {
-            throw ExceptionHelper.wrapOrThrow(de);
+            throw ExceptionHelper.convertToRuntimeException(de);
         }
     }
     
@@ -579,7 +579,7 @@ public class Document implements DocListener {
 					"EEE MMM dd HH:mm:ss zzz yyyy");
 			return add(new Meta(Element.CREATIONDATE, sdf.format(new Date())));
 		} catch (DocumentException de) {
-            throw ExceptionHelper.wrapOrThrow(de);
+            throw ExceptionHelper.convertToRuntimeException(de);
         }
     }
     

--- a/openpdf/src/main/java/com/lowagie/text/ExceptionHelper.java
+++ b/openpdf/src/main/java/com/lowagie/text/ExceptionHelper.java
@@ -1,0 +1,12 @@
+package com.lowagie.text;
+
+
+public class ExceptionHelper {
+
+    public static RuntimeException convertToRuntimeException(Exception exception) {
+        if (exception instanceof RuntimeException) {
+            return (RuntimeException) exception;
+        }
+        return new RuntimeException(exception);
+    }
+}

--- a/openpdf/src/main/java/com/lowagie/text/Font.java
+++ b/openpdf/src/main/java/com/lowagie/text/Font.java
@@ -53,7 +53,7 @@ import java.awt.Color;
 
 import com.lowagie.text.html.Markup;
 import com.lowagie.text.pdf.BaseFont;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 
 /**
  * Contains all the specifications of a font: fontfamily, size, style and color.
@@ -719,7 +719,7 @@ public class Font implements Comparable {
 		try {
 			cfont = BaseFont.createFont(fontName, encoding, false);
 		} catch (Exception ee) {
-			throw ExceptionHelper.wrapOrThrow(ee);
+			throw ExceptionHelper.convertToRuntimeException(ee);
 		}
 		return cfont;
 	}

--- a/openpdf/src/main/java/com/lowagie/text/FontFactoryImp.java
+++ b/openpdf/src/main/java/com/lowagie/text/FontFactoryImp.java
@@ -62,7 +62,7 @@ import java.util.Set;
 
 import com.lowagie.text.html.Markup;
 import com.lowagie.text.pdf.BaseFont;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 
 /**
  * If you are using True Type fonts, you can declare the paths of the different ttf- and ttc-files
@@ -212,7 +212,7 @@ public class FontFactoryImp implements FontProvider {
         }
         catch(DocumentException de) {
             // this shouldn't happen
-            throw ExceptionHelper.wrapOrThrow(de);
+            throw ExceptionHelper.convertToRuntimeException(de);
         }
         catch(IOException ioe) {
             // the font is registered as a true type font, but the path was wrong
@@ -588,10 +588,10 @@ public class FontFactoryImp implements FontProvider {
         }
         catch(DocumentException de) {
             // this shouldn't happen
-            throw ExceptionHelper.wrapOrThrow(de);
+            throw ExceptionHelper.convertToRuntimeException(de);
         }
         catch(IOException ioe) {
-            throw ExceptionHelper.wrapOrThrow(ioe);
+            throw ExceptionHelper.convertToRuntimeException(ioe);
         }
     }
 

--- a/openpdf/src/main/java/com/lowagie/text/Image.java
+++ b/openpdf/src/main/java/com/lowagie/text/Image.java
@@ -73,7 +73,7 @@ import com.lowagie.text.pdf.PdfStream;
 import com.lowagie.text.pdf.PdfTemplate;
 import com.lowagie.text.pdf.PdfWriter;
 import com.lowagie.text.pdf.codec.CCITTG4Encoder;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 
 /**
  * An <CODE>Image</CODE> is the representation of a graphic element (JPEG, PNG
@@ -700,7 +700,7 @@ public abstract class Image extends Rectangle {
 					sm.makeMask();
 					img.setImageMask(sm);
 				} catch (DocumentException de) {
-					throw ExceptionHelper.wrapOrThrow(de);
+					throw ExceptionHelper.convertToRuntimeException(de);
 				}
 			}
 			return img;
@@ -905,7 +905,7 @@ public abstract class Image extends Rectangle {
 					.getDeclaredConstructor(Image.class);
 			return (Image) constructor.newInstance(image);
 		} catch (Exception e) {
-			throw ExceptionHelper.wrapOrThrow(e);
+			throw ExceptionHelper.convertToRuntimeException(e);
 		}
 	}
 

--- a/openpdf/src/main/java/com/lowagie/text/ImageLoader.java
+++ b/openpdf/src/main/java/com/lowagie/text/ImageLoader.java
@@ -45,7 +45,7 @@
 
 package com.lowagie.text;
 
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import org.apache.commons.io.IOUtils;
 import org.apache.sanselan.common.byteSources.ByteSourceArray;
 import org.apache.sanselan.formats.bmp.BmpImageParser;
@@ -72,7 +72,7 @@ public class ImageLoader {
             return Image.getInstance(bufferedImage, null, false);
 
         } catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
 
@@ -84,7 +84,7 @@ public class ImageLoader {
             return Image.getInstance(bufferedImage, null, false);
 
         } catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
 
@@ -96,7 +96,7 @@ public class ImageLoader {
             return Image.getInstance(bufferedImage, null, false);
 
         } catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
 
@@ -109,7 +109,7 @@ public class ImageLoader {
             return Image.getInstance(bufferedImage, null, false);
 
         } catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
 
@@ -121,7 +121,7 @@ public class ImageLoader {
             return Image.getInstance(bufferedImage, null, false);
 
         } catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
 
@@ -132,7 +132,7 @@ public class ImageLoader {
             return Image.getInstance(bufferedImage, null, false);
 
         } catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
 
@@ -143,7 +143,7 @@ public class ImageLoader {
             return Image.getInstance(bufferedImage, null, false);
 
         } catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
 
@@ -154,7 +154,7 @@ public class ImageLoader {
             return Image.getInstance(bufferedImage, null, false);
 
         } catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
 

--- a/openpdf/src/main/java/com/lowagie/text/SimpleCell.java
+++ b/openpdf/src/main/java/com/lowagie/text/SimpleCell.java
@@ -56,7 +56,7 @@ import com.lowagie.text.pdf.PdfContentByte;
 import com.lowagie.text.pdf.PdfPCell;
 import com.lowagie.text.pdf.PdfPCellEvent;
 import com.lowagie.text.pdf.PdfPTable;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 
 /**
  * Rectangle that can be used for Cells.
@@ -523,7 +523,7 @@ public class SimpleCell extends Rectangle implements PdfPCellEvent, TextElementA
 			return false;
 		}
 		catch(BadElementException e) {
-			throw ExceptionHelper.wrapOrThrow(e);
+			throw ExceptionHelper.convertToRuntimeException(e);
 		}
 	}
 	/**

--- a/openpdf/src/main/java/com/lowagie/text/SimpleTable.java
+++ b/openpdf/src/main/java/com/lowagie/text/SimpleTable.java
@@ -55,7 +55,7 @@ import com.lowagie.text.error_messages.MessageLocalization;
 import com.lowagie.text.pdf.PdfContentByte;
 import com.lowagie.text.pdf.PdfPTable;
 import com.lowagie.text.pdf.PdfPTableEvent;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 
 /**
  * Rectangle that can be used for Cells.
@@ -350,7 +350,7 @@ public class SimpleTable extends Rectangle implements PdfPTableEvent, TextElemen
 			return false;
 		}
 		catch(BadElementException e) {
-			throw ExceptionHelper.wrapOrThrow(e);
+			throw ExceptionHelper.convertToRuntimeException(e);
 		}
 	}
 }

--- a/openpdf/src/main/java/com/lowagie/text/Table.java
+++ b/openpdf/src/main/java/com/lowagie/text/Table.java
@@ -60,7 +60,7 @@ import com.lowagie.text.error_messages.MessageLocalization;
 
 import com.lowagie.text.pdf.PdfPCell;
 import com.lowagie.text.pdf.PdfPTable;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 
 /**
  * A <CODE>Table</CODE> is a <CODE>Rectangle</CODE> that contains <CODE>Cell</CODE>s,
@@ -1185,7 +1185,7 @@ public class Table extends Rectangle implements LargeElement {
             }
         }
         catch(BadElementException bee) {
-            throw ExceptionHelper.wrapOrThrow(bee);
+            throw ExceptionHelper.convertToRuntimeException(bee);
         }
     }
     

--- a/openpdf/src/main/java/com/lowagie/text/factories/ElementFactory.java
+++ b/openpdf/src/main/java/com/lowagie/text/factories/ElementFactory.java
@@ -66,7 +66,7 @@ import com.lowagie.text.Cell;
 import com.lowagie.text.ChapterAutoNumber;
 import com.lowagie.text.Chunk;
 import com.lowagie.text.ElementTags;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import com.lowagie.text.FontFactory;
 import com.lowagie.text.Image;
 import com.lowagie.text.List;
@@ -395,7 +395,7 @@ public class ElementFactory {
 			setRectangleProperties(table, attributes);
 			return table;
 		} catch (BadElementException e) {
-			throw ExceptionHelper.wrapOrThrow(e);
+			throw ExceptionHelper.convertToRuntimeException(e);
 		}
 	}
 

--- a/openpdf/src/main/java/com/lowagie/text/pdf/AcroFields.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/AcroFields.java
@@ -62,7 +62,7 @@ import org.w3c.dom.Node;
 
 import com.lowagie.text.DocumentException;
 import com.lowagie.text.Element;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import com.lowagie.text.Image;
 import com.lowagie.text.Rectangle;
 import com.lowagie.text.pdf.codec.Base64;
@@ -145,7 +145,7 @@ public class AcroFields {
             xfa = new XfaForm(reader);
         }
         catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
         if (writer instanceof PdfStamperImp) {
             append = ((PdfStamperImp)writer).isAppend();
@@ -552,7 +552,7 @@ public class AcroFields {
             return ret;
         }
         catch (IOException ioe) {
-            throw ExceptionHelper.wrapOrThrow(ioe);
+            throw ExceptionHelper.convertToRuntimeException(ioe);
         }
     }
 
@@ -840,7 +840,7 @@ public class AcroFields {
 					valBytes = PdfReader.getStreamBytes((PRStream)v);
 	                return new String(valBytes);
 				} catch (IOException e) {
-					throw ExceptionHelper.wrapOrThrow(e);
+					throw ExceptionHelper.convertToRuntimeException(e);
 				}
         }
         
@@ -1085,7 +1085,7 @@ public class AcroFields {
             return true;
         }
         catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
 
@@ -2225,7 +2225,7 @@ public class AcroFields {
             return pk;
         }
         catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
 
@@ -2249,7 +2249,7 @@ public class AcroFields {
             }
         }
         catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
         finally {
             try{rf.close();}catch(Exception e){}
@@ -2573,7 +2573,7 @@ public class AcroFields {
             return newButton;
         }
         catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
 

--- a/openpdf/src/main/java/com/lowagie/text/pdf/Barcode.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/Barcode.java
@@ -50,7 +50,7 @@ package com.lowagie.text.pdf;
 
 import java.awt.Color;
 
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import com.lowagie.text.Image;
 import com.lowagie.text.Rectangle;
 /** Base class containing properties and methods common to all
@@ -424,7 +424,7 @@ public abstract class Barcode {
             return Image.getInstance(createTemplateWithBarcode(cb, barColor, textColor));
         }
         catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
     

--- a/openpdf/src/main/java/com/lowagie/text/pdf/Barcode128.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/Barcode128.java
@@ -55,7 +55,7 @@ import com.lowagie.text.error_messages.MessageLocalization;
 
 import com.lowagie.text.Element;
 import com.lowagie.text.Rectangle;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 
 /**
  * Implements the code 128 and UCC/EAN-128. Other symbologies are allowed in raw mode.<p>
@@ -242,7 +242,7 @@ public class Barcode128 extends Barcode{
             codeType = CODE128;
         }
         catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
 

--- a/openpdf/src/main/java/com/lowagie/text/pdf/Barcode39.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/Barcode39.java
@@ -55,7 +55,7 @@ import java.awt.image.MemoryImageSource;
 import com.lowagie.text.error_messages.MessageLocalization;
 
 import com.lowagie.text.Element;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import com.lowagie.text.Rectangle;
 
 /** Implements the code 39 and code 39 extended. The default parameters are:
@@ -159,7 +159,7 @@ public class Barcode39 extends Barcode{
             extended = false;
         }
         catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
     

--- a/openpdf/src/main/java/com/lowagie/text/pdf/BarcodeCodabar.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/BarcodeCodabar.java
@@ -55,7 +55,7 @@ import java.awt.image.MemoryImageSource;
 import com.lowagie.text.error_messages.MessageLocalization;
 
 import com.lowagie.text.Element;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import com.lowagie.text.Rectangle;
 
 /** Implements the code codabar. The default parameters are:
@@ -124,7 +124,7 @@ public class BarcodeCodabar extends Barcode{
             codeType = CODABAR;
         }
         catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
     

--- a/openpdf/src/main/java/com/lowagie/text/pdf/BarcodeEAN.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/BarcodeEAN.java
@@ -53,7 +53,7 @@ import java.awt.image.MemoryImageSource;
 import java.util.Arrays;
 import com.lowagie.text.error_messages.MessageLocalization;
 
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import com.lowagie.text.Rectangle;
 
 /** Generates barcodes in several formats: EAN13, EAN8, UPCA, UPCE,
@@ -184,7 +184,7 @@ public class BarcodeEAN extends Barcode{
             code = "";
         }
         catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
     

--- a/openpdf/src/main/java/com/lowagie/text/pdf/BarcodeInter25.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/BarcodeInter25.java
@@ -55,7 +55,7 @@ import java.awt.image.MemoryImageSource;
 import com.lowagie.text.error_messages.MessageLocalization;
 
 import com.lowagie.text.Element;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import com.lowagie.text.Rectangle;
 
 /** Implements the code interleaved 2 of 5. The text can include
@@ -107,7 +107,7 @@ public class BarcodeInter25 extends Barcode{
             checksumText = false;
         }
         catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
     

--- a/openpdf/src/main/java/com/lowagie/text/pdf/CFFFont.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/CFFFont.java
@@ -71,7 +71,7 @@ package com.lowagie.text.pdf;
 import java.util.Iterator;
 import java.util.LinkedList;
 
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 
 public class CFFFont {
     
@@ -190,7 +190,7 @@ public class CFFFont {
             return (char)(i & 0xff);
         }
         catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
     
@@ -199,7 +199,7 @@ public class CFFFont {
             return buf.readChar();
         }
         catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
     
@@ -217,7 +217,7 @@ public class CFFFont {
             buf.seek(offset);
         }
         catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
     
@@ -226,7 +226,7 @@ public class CFFFont {
             return buf.readShort();
         }
         catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
     
@@ -235,7 +235,7 @@ public class CFFFont {
             return buf.readInt();
         }
         catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
     
@@ -244,7 +244,7 @@ public class CFFFont {
             return buf.getFilePointer();
         }
         catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
     int nextIndexOffset;
@@ -423,7 +423,7 @@ public class CFFFont {
                     buffer[i] = buf.readByte();
             }
             catch (Exception e) {
-                throw ExceptionHelper.wrapOrThrow(e);
+                throw ExceptionHelper.convertToRuntimeException(e);
             }
             //System.err.println("finished range emit");
         }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/ColumnText.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/ColumnText.java
@@ -57,7 +57,7 @@ import com.lowagie.text.error_messages.MessageLocalization;
 import com.lowagie.text.Chunk;
 import com.lowagie.text.DocumentException;
 import com.lowagie.text.Element;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import com.lowagie.text.Image;
 import com.lowagie.text.ListItem;
 import com.lowagie.text.Paragraph;
@@ -1124,7 +1124,7 @@ public class ColumnText {
             ct.go();
         }
         catch (DocumentException e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
         canvas.restoreState();
     }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/DefaultFontMapper.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/DefaultFontMapper.java
@@ -50,7 +50,7 @@ import java.awt.Font;
 import java.io.File;
 import java.util.HashMap;
 
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 /** Default class to map awt fonts to BaseFont.
  * @author Paulo Soares (psoares@consiste.pt)
  */
@@ -170,7 +170,7 @@ public class DefaultFontMapper implements FontMapper {
             return BaseFont.createFont(fontKey, BaseFont.CP1252, false);
         }
         catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
     

--- a/openpdf/src/main/java/com/lowagie/text/pdf/DocumentFont.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/DocumentFont.java
@@ -50,7 +50,7 @@ import java.io.IOException;
 import java.util.HashMap;
 
 import com.lowagie.text.DocumentException;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 
 /**
  *
@@ -131,7 +131,7 @@ public class DocumentFont extends BaseFont {
                         cjkMirror = BaseFont.createFont(fontName, cjkEncs[k], false);
                     }
                     catch (Exception e) {
-                        throw ExceptionHelper.wrapOrThrow(e);
+                        throw ExceptionHelper.convertToRuntimeException(e);
                     }
                     return;
                 }
@@ -147,7 +147,7 @@ public class DocumentFont extends BaseFont {
 	                        cjkMirror = BaseFont.createFont(cjkNames2[k], cjkEncs2[k], false);
 	                    }
 	                    catch (Exception e) {
-	                        throw ExceptionHelper.wrapOrThrow(e);
+	                        throw ExceptionHelper.convertToRuntimeException(e);
 	                    }
 	                    return;
 	                }
@@ -178,7 +178,7 @@ public class DocumentFont extends BaseFont {
             }
             
         } catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
     
@@ -276,7 +276,7 @@ public class DocumentFont extends BaseFont {
             }
         }
         catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
     
@@ -324,7 +324,7 @@ public class DocumentFont extends BaseFont {
                 bf = BaseFont.createFont(fontName, WINANSI, false);
             }
             catch (Exception e) {
-                throw ExceptionHelper.wrapOrThrow(e);
+                throw ExceptionHelper.convertToRuntimeException(e);
             }
             int e[] = uni2byte.toOrderedKeys();
             for (int k = 0; k < e.length; ++k) {

--- a/openpdf/src/main/java/com/lowagie/text/pdf/FontDetails.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/FontDetails.java
@@ -53,7 +53,7 @@ import java.awt.font.GlyphVector;
 import java.io.UnsupportedEncodingException;
 import java.util.HashMap;
 
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import com.lowagie.text.Utilities;
 
 /**
@@ -237,7 +237,7 @@ class FontDetails {
                     b = s.getBytes(CJKFont.CJK_ENCODING);
                 }
                 catch (UnsupportedEncodingException e) {
-                    throw ExceptionHelper.wrapOrThrow(e);
+                    throw ExceptionHelper.convertToRuntimeException(e);
                 }
                 break;
             }
@@ -276,7 +276,7 @@ class FontDetails {
 			byte[] b = s.getBytes(CJKFont.CJK_ENCODING);
 			return b;
 		} catch (UnsupportedEncodingException e) {
-			throw ExceptionHelper.wrapOrThrow(e);
+			throw ExceptionHelper.convertToRuntimeException(e);
 		}
 	}
 	
@@ -319,7 +319,7 @@ class FontDetails {
             }
         }
         catch(Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
     

--- a/openpdf/src/main/java/com/lowagie/text/pdf/OcspClientBouncyCastle.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/OcspClientBouncyCastle.java
@@ -127,7 +127,7 @@ import org.bouncycastle.operator.DigestCalculatorProvider;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaDigestCalculatorProviderBuilder;
 
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import com.lowagie.text.error_messages.MessageLocalization;
 
 /**
@@ -274,7 +274,7 @@ public class OcspClientBouncyCastle implements OcspClient {
         }
       }
     } catch (Exception ex) {
-      throw ExceptionHelper.wrapOrThrow(ex);
+      throw ExceptionHelper.convertToRuntimeException(ex);
     }
     return null;
   }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/OutputStreamEncryption.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/OutputStreamEncryption.java
@@ -47,7 +47,7 @@
  * http://www.lowagie.com/iText/
  */
 package com.lowagie.text.pdf;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import com.lowagie.text.pdf.crypto.AESCipher;
 import com.lowagie.text.pdf.crypto.IVGenerator;
 import com.lowagie.text.pdf.crypto.ARCFOUREncryption;
@@ -81,7 +81,7 @@ public class OutputStreamEncryption extends OutputStream {
                 arcfour.prepareARCFOURKey(key, off, len);
             }
         } catch (Exception ex) {
-            throw ExceptionHelper.wrapOrThrow(ex);
+            throw ExceptionHelper.convertToRuntimeException(ex);
         }
     }
     
@@ -209,7 +209,7 @@ public class OutputStreamEncryption extends OutputStream {
                 try {
                     b = cipher.doFinal();
                 } catch (Exception ex) {
-                    throw ExceptionHelper.wrapOrThrow(ex);
+                    throw ExceptionHelper.convertToRuntimeException(ex);
                 }
                 out.write(b, 0, b.length);
             }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PRStream.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PRStream.java
@@ -56,7 +56,7 @@ import java.util.zip.Deflater;
 import java.util.zip.DeflaterOutputStream;
 
 import com.lowagie.text.Document;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 
 public class PRStream extends PdfStream {
     
@@ -120,7 +120,7 @@ public class PRStream extends PdfStream {
                 bytes = stream.toByteArray();
             }
             catch (IOException ioe) {
-                throw ExceptionHelper.wrapOrThrow(ioe);
+                throw ExceptionHelper.convertToRuntimeException(ioe);
             }
             put(PdfName.FILTER, PdfName.FLATEDECODE);
         }
@@ -167,7 +167,7 @@ public class PRStream extends PdfStream {
                 this.compressionLevel = compressionLevel;
             }
             catch (IOException ioe) {
-                throw ExceptionHelper.wrapOrThrow(ioe);
+                throw ExceptionHelper.convertToRuntimeException(ioe);
             }
             put(PdfName.FILTER, PdfName.FLATEDECODE);
         }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfAcroForm.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfAcroForm.java
@@ -52,7 +52,7 @@ package com.lowagie.text.pdf;
 import java.util.HashMap;
 import java.util.Iterator;
 
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import com.lowagie.text.Rectangle;
 
 /**
@@ -472,7 +472,7 @@ public class PdfAcroForm extends PdfDictionary {
             font = BaseFont.createFont(BaseFont.ZAPFDINGBATS, BaseFont.WINANSI, BaseFont.NOT_EMBEDDED);
         }
         catch(Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
         float size = (ury - lly);
         PdfAppearance tpOn = PdfAppearance.createAppearance(writer, urx - llx, ury - lly);

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfContentByte.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfContentByte.java
@@ -63,7 +63,7 @@ import java.util.Map;
 import com.lowagie.text.Annotation;
 import com.lowagie.text.DocumentException;
 import com.lowagie.text.Element;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import com.lowagie.text.Image;
 import com.lowagie.text.ImgJBIG2;
 import com.lowagie.text.Rectangle;
@@ -3062,7 +3062,7 @@ public class PdfContentByte {
         	dict.toPdf(writer, content);
         }
         catch (IOException e) {
-        	throw ExceptionHelper.wrapOrThrow(e);
+        	throw ExceptionHelper.convertToRuntimeException(e);
         }
         content.append(" BDC").append_i(separator);
     }
@@ -3097,7 +3097,7 @@ public class PdfContentByte {
                 property.toPdf(writer, content);
             }
             catch (Exception e) {
-                throw ExceptionHelper.wrapOrThrow(e);
+                throw ExceptionHelper.convertToRuntimeException(e);
             }
         else {
             PdfObject[] objs;

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfCopy.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfCopy.java
@@ -55,7 +55,7 @@ import java.util.Iterator;
 
 import com.lowagie.text.Document;
 import com.lowagie.text.DocumentException;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import com.lowagie.text.Rectangle;
 import java.util.ArrayList;
 
@@ -427,7 +427,7 @@ public class PdfCopy extends PdfWriter {
             return theCat;
         }
         catch (IOException e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
     
@@ -745,7 +745,7 @@ public class PdfCopy extends PdfWriter {
                 }
             }
             catch (IOException e) {
-                throw ExceptionHelper.wrapOrThrow(e);
+                throw ExceptionHelper.convertToRuntimeException(e);
             }
         }
     }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfCopyFieldsImp.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfCopyFieldsImp.java
@@ -59,7 +59,7 @@ import com.lowagie.text.error_messages.MessageLocalization;
 
 import com.lowagie.text.Document;
 import com.lowagie.text.DocumentException;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import com.lowagie.text.exceptions.BadPasswordException;
 
 /**
@@ -362,7 +362,7 @@ class PdfCopyFieldsImp extends PdfWriter {
             closeIt();
         }
         catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
     
@@ -550,7 +550,7 @@ class PdfCopyFieldsImp extends PdfWriter {
             return cat;
         }
         catch (IOException e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
 

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfDocument.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfDocument.java
@@ -86,7 +86,7 @@ import com.lowagie.text.pdf.collection.PdfCollection;
 import com.lowagie.text.pdf.draw.DrawInterface;
 import com.lowagie.text.pdf.internal.PdfAnnotationsImp;
 import com.lowagie.text.pdf.internal.PdfViewerPreferencesImp;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 
 /**
  * <CODE>PdfDocument</CODE> is the class that is used by <CODE>PdfWriter</CODE>
@@ -290,7 +290,7 @@ public class PdfDocument extends Document {
                     put(PdfName.NAMES, writer.addToBody(names).getIndirectReference());
             }
             catch (IOException e) {
-                throw ExceptionHelper.wrapOrThrow(e);
+                throw ExceptionHelper.convertToRuntimeException(e);
             }
         }
 
@@ -311,7 +311,7 @@ public class PdfDocument extends Document {
             try {
                 put(PdfName.AA, writer.addToBody(actions).getIndirectReference());
             } catch (Exception e) {
-                throw ExceptionHelper.wrapOrThrow(e);
+                throw ExceptionHelper.convertToRuntimeException(e);
             }
         }
     }
@@ -792,7 +792,7 @@ public class PdfDocument extends Document {
             initPage();
         }
         catch(DocumentException de) {
-            throw ExceptionHelper.wrapOrThrow(de);
+            throw ExceptionHelper.convertToRuntimeException(de);
         }
     }
 
@@ -824,7 +824,7 @@ public class PdfDocument extends Document {
             writeOutlines();
         }
         catch(Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
 
         writer.close();
@@ -966,10 +966,10 @@ public class PdfDocument extends Document {
         }
         catch(DocumentException de) {
         	// maybe this never happens, but it's better to check.
-        	throw ExceptionHelper.wrapOrThrow(de);
+        	throw ExceptionHelper.convertToRuntimeException(de);
         }
         catch (IOException ioe) {
-            throw ExceptionHelper.wrapOrThrow(ioe);
+            throw ExceptionHelper.convertToRuntimeException(ioe);
         }
         return true;
     }
@@ -1184,7 +1184,7 @@ public class PdfDocument extends Document {
             }
         }
         catch(Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
         leading = oldleading;
         alignment = oldAlignment;
@@ -1283,7 +1283,7 @@ public class PdfDocument extends Document {
           flushLines();
         }
       } catch (DocumentException ex) {
-        throw ExceptionHelper.wrapOrThrow(ex);
+        throw ExceptionHelper.convertToRuntimeException(ex);
         }
     }
 
@@ -1877,7 +1877,7 @@ public class PdfDocument extends Document {
                 catalog.put(PdfName.ACROFORM, writer.addToBody(annotationsImp.getAcroForm()).getIndirectReference());
             }
             catch (IOException e) {
-                throw ExceptionHelper.wrapOrThrow(e);
+                throw ExceptionHelper.convertToRuntimeException(e);
             }
         }
 
@@ -2122,7 +2122,7 @@ public class PdfDocument extends Document {
             documentLevelJS.put(SIXTEEN_DIGITS.format(jsCounter++), writer.addToBody(js).getIndirectReference());
         }
         catch (IOException e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
     void addJavaScript(String name, PdfAction js) {
@@ -2132,7 +2132,7 @@ public class PdfDocument extends Document {
             documentLevelJS.put(name, writer.addToBody(js).getIndirectReference());
         }
         catch (IOException e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
 

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfEncodings.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfEncodings.java
@@ -47,7 +47,7 @@
 
 package com.lowagie.text.pdf;
 
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import com.lowagie.text.error_messages.MessageLocalization;
 
 import java.io.BufferedReader;
@@ -220,7 +220,7 @@ public class PdfEncodings {
 		try {
 			return text.getBytes(encoding);
 		} catch (UnsupportedEncodingException e) {
-			throw ExceptionHelper.wrapOrThrow(e);
+			throw ExceptionHelper.convertToRuntimeException(e);
 		}
 	}
 
@@ -277,7 +277,7 @@ public class PdfEncodings {
 		try {
 			return String.valueOf(char1).getBytes(encoding);
 		} catch (UnsupportedEncodingException e) {
-			throw ExceptionHelper.wrapOrThrow(e);
+			throw ExceptionHelper.convertToRuntimeException(e);
 		}
 	}
 
@@ -326,7 +326,7 @@ public class PdfEncodings {
 		try {
 			return new String(bytes, encoding);
 		} catch (UnsupportedEncodingException e) {
-			throw ExceptionHelper.wrapOrThrow(e);
+			throw ExceptionHelper.convertToRuntimeException(e);
 		}
 	}
 
@@ -399,7 +399,7 @@ public class PdfEncodings {
 				cmaps.putIfAbsent(name, planes);
 			}
 		} catch (IOException e) {
-			throw ExceptionHelper.wrapOrThrow(e);
+			throw ExceptionHelper.convertToRuntimeException(e);
 		}
 	}
 
@@ -448,7 +448,7 @@ public class PdfEncodings {
 			}
 			return decodeSequence(seq, start, length, planes);
 		} catch (IOException e) {
-			throw ExceptionHelper.wrapOrThrow(e);
+			throw ExceptionHelper.convertToRuntimeException(e);
 		}
 	}
 

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfEncryption.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfEncryption.java
@@ -58,7 +58,7 @@ import java.io.ByteArrayOutputStream;
 import java.security.MessageDigest;
 import java.security.cert.Certificate;
 
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 
 /**
  * 
@@ -138,7 +138,7 @@ public class PdfEncryption {
 		try {
 			md5 = MessageDigest.getInstance("MD5");
 		} catch (Exception e) {
-			throw ExceptionHelper.wrapOrThrow(e);
+			throw ExceptionHelper.convertToRuntimeException(e);
 		}
 		publicKeyHandler = new PdfPublicKeySecurityHandler();
 	}
@@ -335,7 +335,7 @@ public class PdfEncryption {
 		try {
 			md5 = MessageDigest.getInstance("MD5");
 		} catch (Exception e) {
-			throw ExceptionHelper.wrapOrThrow(e);
+			throw ExceptionHelper.convertToRuntimeException(e);
 		}
 		long time = System.currentTimeMillis();
 		long mem = Runtime.getRuntime().freeMemory();
@@ -424,7 +424,7 @@ public class PdfEncryption {
 			try {
 				recipients = publicKeyHandler.getEncodedRecipients();
 			} catch (Exception f) {
-				throw ExceptionHelper.wrapOrThrow(f);
+				throw ExceptionHelper.convertToRuntimeException(f);
 			}
 
 			if (revision == STANDARD_ENCRYPTION_40) {
@@ -477,7 +477,7 @@ public class PdfEncryption {
 					md.update(new byte[] { (byte) 255, (byte) 255, (byte) 255,
 							(byte) 255 });
 			} catch (Exception f) {
-				throw ExceptionHelper.wrapOrThrow(f);
+				throw ExceptionHelper.convertToRuntimeException(f);
 			}
 
 			byte[] mdResult = md.digest();
@@ -553,7 +553,7 @@ public class PdfEncryption {
 			os2.finish();
 			return ba.toByteArray();
 		} catch (IOException ex) {
-			throw ExceptionHelper.wrapOrThrow(ex);
+			throw ExceptionHelper.convertToRuntimeException(ex);
 		}
 	}
 
@@ -573,7 +573,7 @@ public class PdfEncryption {
 				ba.write(b2);
 			return ba.toByteArray();
 		} catch (IOException ex) {
-			throw ExceptionHelper.wrapOrThrow(ex);
+			throw ExceptionHelper.convertToRuntimeException(ex);
 		}
 	}
 

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfFont.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfFont.java
@@ -49,7 +49,7 @@
 
 package com.lowagie.text.pdf;
 
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import com.lowagie.text.Image;
 
 /**
@@ -178,7 +178,7 @@ class PdfFont implements Comparable {
             return new PdfFont(bf, 12);
         }
         catch (Exception ee) {
-            throw ExceptionHelper.wrapOrThrow(ee);
+            throw ExceptionHelper.convertToRuntimeException(ee);
         }
     }
     void setHorizontalScaling(float hScale) {

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfFunction.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfFunction.java
@@ -48,7 +48,7 @@ package com.lowagie.text.pdf;
 
 import java.io.IOException;
 
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 /** Implements PDF functions.
  *
  * @author Paulo Soares (psoares@consiste.pt)
@@ -73,7 +73,7 @@ public class PdfFunction {
             }
         }
         catch (IOException ioe) {
-            throw ExceptionHelper.wrapOrThrow(ioe);
+            throw ExceptionHelper.convertToRuntimeException(ioe);
         }
         return reference;
     }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfICCBased.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfICCBased.java
@@ -49,7 +49,7 @@ package com.lowagie.text.pdf;
 import java.awt.color.ICC_Profile;
 import com.lowagie.text.error_messages.MessageLocalization;
 
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 
 /**
  * A <CODE>PdfICCBased</CODE> defines a ColorSpace
@@ -96,7 +96,7 @@ public class PdfICCBased extends PdfStream {
             bytes = profile.getData();
             flateCompress(compressionLevel);
         } catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
 }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfPCell.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfPCell.java
@@ -55,7 +55,7 @@ import com.lowagie.text.error_messages.MessageLocalization;
 import com.lowagie.text.Chunk;
 import com.lowagie.text.DocumentException;
 import com.lowagie.text.Element;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import com.lowagie.text.Image;
 import com.lowagie.text.Phrase;
 import com.lowagie.text.Rectangle;
@@ -992,7 +992,7 @@ public class PdfPCell extends Rectangle{
 				try {
 					ct.go(true);
 				} catch (DocumentException e) {
-					throw ExceptionHelper.wrapOrThrow(e);
+					throw ExceptionHelper.convertToRuntimeException(e);
 				}
 				if (pivoted)
 					setBottom(getTop() - getEffectivePaddingTop() - getEffectivePaddingBottom() - ct.getFilledWidth());

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfPKCS7.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfPKCS7.java
@@ -115,7 +115,7 @@ import org.bouncycastle.operator.DigestCalculatorProvider;
 import org.bouncycastle.operator.jcajce.JcaDigestCalculatorProviderBuilder;
 import org.bouncycastle.tsp.TimeStampToken;
 
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import com.lowagie.text.error_messages.MessageLocalization;
 
 /**
@@ -330,7 +330,7 @@ public class PdfPKCS7 {
         sig = Signature.getInstance("SHA1withRSA", provider);
       sig.initVerify(signCert.getPublicKey());
     } catch (Exception e) {
-      throw ExceptionHelper.wrapOrThrow(e);
+      throw ExceptionHelper.convertToRuntimeException(e);
     }
   }
 
@@ -560,7 +560,7 @@ public class PdfPKCS7 {
         sig = Signature.getInstance(getDigestAlgorithm(), provider);
       sig.initVerify(signCert.getPublicKey());
     } catch (Exception e) {
-      throw ExceptionHelper.wrapOrThrow(e);
+      throw ExceptionHelper.convertToRuntimeException(e);
     }
   }
 
@@ -870,7 +870,7 @@ public class PdfPKCS7 {
       k.load(fin, null);
       return k;
     } catch (Exception e) {
-      throw ExceptionHelper.wrapOrThrow(e);
+      throw ExceptionHelper.convertToRuntimeException(e);
     } finally {
       try {
         if (fin != null) {
@@ -1156,7 +1156,7 @@ public class PdfPKCS7 {
       return (ASN1Primitive) seq
           .getObjectAt(seq.getObjectAt(0) instanceof DERTaggedObject ? 3 : 2);
     } catch (IOException e) {
-      throw ExceptionHelper.wrapOrThrow(e);
+      throw ExceptionHelper.convertToRuntimeException(e);
     }
   }
 
@@ -1174,7 +1174,7 @@ public class PdfPKCS7 {
       return (ASN1Primitive) seq
           .getObjectAt(seq.getObjectAt(0) instanceof DERTaggedObject ? 5 : 4);
     } catch (IOException e) {
-      throw ExceptionHelper.wrapOrThrow(e);
+      throw ExceptionHelper.convertToRuntimeException(e);
     }
   }
 
@@ -1189,7 +1189,7 @@ public class PdfPKCS7 {
     try {
       return new X509Name((ASN1Sequence) getIssuer(cert.getTBSCertificate()));
     } catch (Exception e) {
-      throw ExceptionHelper.wrapOrThrow(e);
+      throw ExceptionHelper.convertToRuntimeException(e);
     }
   }
 
@@ -1204,7 +1204,7 @@ public class PdfPKCS7 {
     try {
       return new X509Name((ASN1Sequence) getSubject(cert.getTBSCertificate()));
     } catch (Exception e) {
-      throw ExceptionHelper.wrapOrThrow(e);
+      throw ExceptionHelper.convertToRuntimeException(e);
     }
   }
 
@@ -1227,7 +1227,7 @@ public class PdfPKCS7 {
 
       return bOut.toByteArray();
     } catch (Exception e) {
-      throw ExceptionHelper.wrapOrThrow(e);
+      throw ExceptionHelper.convertToRuntimeException(e);
     }
   }
 
@@ -1254,7 +1254,7 @@ public class PdfPKCS7 {
       } else if (digestEncryptionAlgorithm.equals("DSA")) {
         this.digestEncryptionAlgorithm = ID_DSA;
       } else
-        throw ExceptionHelper.wrapOrThrow(new NoSuchAlgorithmException(
+        throw ExceptionHelper.convertToRuntimeException(new NoSuchAlgorithmException(
             MessageLocalization.getComposedMessage("unknown.key.algorithm.1",
                 digestEncryptionAlgorithm)));
     }
@@ -1417,7 +1417,7 @@ public class PdfPKCS7 {
 
       return bOut.toByteArray();
     } catch (Exception e) {
-      throw ExceptionHelper.wrapOrThrow(e);
+      throw ExceptionHelper.convertToRuntimeException(e);
     }
   }
 
@@ -1493,7 +1493,7 @@ public class PdfPKCS7 {
       return getAuthenticatedAttributeSet(secondDigest, signingTime, ocsp)
           .getEncoded(ASN1Encoding.DER);
     } catch (Exception e) {
-      throw ExceptionHelper.wrapOrThrow(e);
+      throw ExceptionHelper.convertToRuntimeException(e);
     }
   }
 
@@ -1544,7 +1544,7 @@ public class PdfPKCS7 {
       }
       return new DERSet(attribute);
     } catch (Exception e) {
-      throw ExceptionHelper.wrapOrThrow(e);
+      throw ExceptionHelper.convertToRuntimeException(e);
     }
   }
 

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfPRow.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfPRow.java
@@ -53,7 +53,7 @@ import java.awt.Color;
 
 import com.lowagie.text.DocumentException;
 import com.lowagie.text.Element;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import com.lowagie.text.Image;
 import com.lowagie.text.Rectangle;
 
@@ -374,7 +374,7 @@ public class PdfPRow {
 				try {
 					canvases[PdfPTable.TEXTCANVAS].addImage(img);
 				} catch (DocumentException e) {
-					throw ExceptionHelper.wrapOrThrow(e);
+					throw ExceptionHelper.convertToRuntimeException(e);
 				}
 			} else {
                 // rotation sponsored by Connection GmbH
@@ -387,7 +387,7 @@ public class PdfPRow {
                     try {
                         ct.go(true);
                     } catch (DocumentException e) {
-                        throw ExceptionHelper.wrapOrThrow(e);
+                        throw ExceptionHelper.convertToRuntimeException(e);
                     }
                     float calcHeight = -ct.getYLine();
                     if (netWidth <= 0 || netHeight <= 0)
@@ -433,7 +433,7 @@ public class PdfPRow {
                         try {
                             ct.go();
                         } catch (DocumentException e) {
-                            throw ExceptionHelper.wrapOrThrow(e);
+                            throw ExceptionHelper.convertToRuntimeException(e);
                         } finally {
                             restoreCanvases(canvases);
                         }
@@ -490,7 +490,7 @@ public class PdfPRow {
                         try {
                             ct.go();
                         } catch (DocumentException e) {
-                            throw ExceptionHelper.wrapOrThrow(e);
+                            throw ExceptionHelper.convertToRuntimeException(e);
                         } finally {
                             if (cell.getRotation() == 180) {
                                 restoreCanvases(canvases);
@@ -624,7 +624,7 @@ public class PdfPRow {
 					status = ct.go(true);
 				}
 				catch (DocumentException e) {
-					throw ExceptionHelper.wrapOrThrow(e);
+					throw ExceptionHelper.convertToRuntimeException(e);
 				}
 				boolean thisEmpty = (ct.getYLine() == y);
 				if (thisEmpty) {

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfPageLabels.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfPageLabels.java
@@ -26,7 +26,7 @@
 
 package com.lowagie.text.pdf;
 
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import com.lowagie.text.error_messages.MessageLocalization;
 import com.lowagie.text.factories.RomanAlphabetFactory;
 import com.lowagie.text.factories.RomanNumberFactory;
@@ -181,7 +181,7 @@ public class PdfPageLabels {
 		try {
 			return PdfNumberTree.writeTree(map, writer);
 		} catch (IOException e) {
-			throw ExceptionHelper.wrapOrThrow(e);
+			throw ExceptionHelper.convertToRuntimeException(e);
 		}
 	}
 

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfPages.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfPages.java
@@ -51,7 +51,7 @@ package com.lowagie.text.pdf;
 
 import com.lowagie.text.Document;
 import com.lowagie.text.DocumentException;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import com.lowagie.text.error_messages.MessageLocalization;
 
 import java.io.IOException;
@@ -97,7 +97,7 @@ public class PdfPages {
             pages.add(current);
         }
         catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
     
@@ -109,7 +109,7 @@ public class PdfPages {
             return (PdfIndirectReference)parents.get(parents.size() - 1);
         }
         catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
     

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfPattern.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfPattern.java
@@ -46,7 +46,7 @@
  */
 package com.lowagie.text.pdf;
 
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 
 /**
  * A <CODE>PdfPattern</CODE> defines a ColorSpace
@@ -93,7 +93,7 @@ public class PdfPattern extends PdfStream {
         try {
             flateCompress(compressionLevel);
         } catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
 }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfReader.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfReader.java
@@ -50,7 +50,7 @@
 package com.lowagie.text.pdf;
 
 import com.lowagie.bouncycastle.BouncyCastleHelper;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import com.lowagie.text.PageSize;
 import com.lowagie.text.Rectangle;
 import com.lowagie.text.error_messages.MessageLocalization;
@@ -847,7 +847,7 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
           md.update(new byte[] { (byte) 255, (byte) 255, (byte) 255, (byte) 255 });
         encryptionKey = md.digest();
       } catch (Exception f) {
-        throw ExceptionHelper.wrapOrThrow(f);
+        throw ExceptionHelper.convertToRuntimeException(f);
       }
     }
 
@@ -932,7 +932,7 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
         return obj;
       }
     } catch (Exception e) {
-      throw ExceptionHelper.wrapOrThrow(e);
+      throw ExceptionHelper.convertToRuntimeException(e);
     }
   }
 
@@ -1007,7 +1007,7 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
         lastXrefPartial = idx;
       return obj;
     } catch (Exception e) {
-      throw ExceptionHelper.wrapOrThrow(e);
+      throw ExceptionHelper.convertToRuntimeException(e);
     }
   }
 
@@ -2031,7 +2031,7 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
       ZCompressorInputStream is = new ZCompressorInputStream(new ByteArrayInputStream(in));
       return IOUtils.toByteArray(is);
     } catch (IOException e) {
-      throw ExceptionHelper.wrapOrThrow(e);
+      throw ExceptionHelper.convertToRuntimeException(e);
     }
   }
 
@@ -3114,7 +3114,7 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
     try {
       tokens.close();
     } catch (IOException e) {
-      throw ExceptionHelper.wrapOrThrow(e);
+      throw ExceptionHelper.convertToRuntimeException(e);
     }
   }
 
@@ -3569,7 +3569,7 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
           }
         }
       } catch (Exception e) {
-        throw ExceptionHelper.wrapOrThrow(e);
+        throw ExceptionHelper.convertToRuntimeException(e);
       }
     }
 

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfSigGenericPKCS.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfSigGenericPKCS.java
@@ -51,7 +51,7 @@ import java.security.PrivateKey;
 import java.security.cert.CRL;
 import java.security.cert.Certificate;
 
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 
 /**
  * A signature dictionary representation for the standard filters.
@@ -115,7 +115,7 @@ public abstract class PdfSigGenericPKCS extends PdfSignature {
             pkcs.setExternalDigest(externalDigest, externalRSAdata, digestEncryptionAlgorithm);
         }
         catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
 

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfSignatureAppearance.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfSignatureAppearance.java
@@ -69,7 +69,7 @@ import java.util.Map;
 import com.lowagie.text.Chunk;
 import com.lowagie.text.DocumentException;
 import com.lowagie.text.Element;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import com.lowagie.text.Font;
 import com.lowagie.text.Image;
 import com.lowagie.text.Paragraph;
@@ -720,7 +720,7 @@ public class PdfSignatureAppearance {
       }
       return size;
     } catch (Exception e) {
-      throw ExceptionHelper.wrapOrThrow(e);
+      throw ExceptionHelper.convertToRuntimeException(e);
     }
   }
 

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfSmartCopy.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfSmartCopy.java
@@ -58,7 +58,7 @@ import java.util.HashMap;
 
 import com.lowagie.text.Document;
 import com.lowagie.text.DocumentException;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 
 /**
  * PdfSmartCopy has the same functionality as PdfCopy,
@@ -197,7 +197,7 @@ public class PdfSmartCopy extends PdfCopy {
                 md5 = MessageDigest.getInstance("MD5");
             }
             catch (Exception e) {
-                throw ExceptionHelper.wrapOrThrow(e);
+                throw ExceptionHelper.convertToRuntimeException(e);
             }
             ByteBuffer bb = new ByteBuffer();
             int level = 100;

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfStamper.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfStamper.java
@@ -59,7 +59,7 @@ import com.lowagie.text.error_messages.MessageLocalization;
 
 import com.lowagie.text.DocWriter;
 import com.lowagie.text.DocumentException;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import com.lowagie.text.Image;
 import com.lowagie.text.Rectangle;
 import com.lowagie.text.pdf.collection.PdfCollection;
@@ -205,7 +205,7 @@ public class PdfStamper
             }
         }
         catch (SignatureException se) {
-            throw ExceptionHelper.wrapOrThrow(se);
+            throw ExceptionHelper.convertToRuntimeException(se);
         }
         buf = new byte[totalBuf];
         byte[] bsig = sig.getSignerContents();

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfStamperImp.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfStamperImp.java
@@ -59,7 +59,7 @@ import org.xml.sax.SAXException;
 
 import com.lowagie.text.Document;
 import com.lowagie.text.DocumentException;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import com.lowagie.text.Image;
 import com.lowagie.text.Rectangle;
 import com.lowagie.text.exceptions.BadPasswordException;
@@ -1241,7 +1241,7 @@ class PdfStamperImp extends PdfWriter {
             }
         }
         catch (IOException e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
 

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfStream.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfStream.java
@@ -59,7 +59,7 @@ import com.lowagie.text.error_messages.MessageLocalization;
 
 import com.lowagie.text.DocWriter;
 import com.lowagie.text.Document;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 
 /**
  * <CODE>PdfStream</CODE> is the Pdf stream object.
@@ -265,7 +265,7 @@ public class PdfStream extends PdfDictionary {
             compressed = true;
         }
         catch(IOException ioe) {
-            throw ExceptionHelper.wrapOrThrow(ioe);
+            throw ExceptionHelper.convertToRuntimeException(ioe);
         }
     }
 

--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfWriter.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfWriter.java
@@ -71,7 +71,7 @@ import com.lowagie.text.DocListener;
 import com.lowagie.text.DocWriter;
 import com.lowagie.text.Document;
 import com.lowagie.text.DocumentException;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import com.lowagie.text.Image;
 import com.lowagie.text.ImgJBIG2;
 import com.lowagie.text.ImgWMF;
@@ -898,7 +898,7 @@ public class PdfWriter extends DocWriter implements
                 getStructureTreeRoot().buildTree();
             }
             catch (Exception e) {
-                throw ExceptionHelper.wrapOrThrow(e);
+                throw ExceptionHelper.convertToRuntimeException(e);
             }
             catalog.put(PdfName.STRUCTTREEROOT, structureTreeRoot.getReference());
             PdfDictionary mi = new PdfDictionary();
@@ -1061,7 +1061,7 @@ public class PdfWriter extends DocWriter implements
             object = addToBody(contents);
         }
         catch(IOException ioe) {
-            throw ExceptionHelper.wrapOrThrow(ioe);
+            throw ExceptionHelper.convertToRuntimeException(ioe);
         }
         page.add(object.getIndirectReference());
         // [U5]
@@ -1150,7 +1150,7 @@ public class PdfWriter extends DocWriter implements
             }
         }
         catch(IOException ioe) {
-            throw ExceptionHelper.wrapOrThrow(ioe);
+            throw ExceptionHelper.convertToRuntimeException(ioe);
         }
     }
 
@@ -1240,7 +1240,7 @@ public class PdfWriter extends DocWriter implements
                 super.close();
             }
             catch(IOException ioe) {
-                throw ExceptionHelper.wrapOrThrow(ioe);
+                throw ExceptionHelper.convertToRuntimeException(ioe);
             }
         }
     }
@@ -2202,7 +2202,7 @@ public class PdfWriter extends DocWriter implements
                 name = (PdfName)obj[0];
         }
         catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
         return name;
     }
@@ -2336,7 +2336,7 @@ public class PdfWriter extends DocWriter implements
                 documentPatterns.put(painter, name);
             }
         } catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
         return name;
     }
@@ -3060,7 +3060,7 @@ public class PdfWriter extends DocWriter implements
                     addToBody(pdfImage, fixedRef);
             }
             catch(IOException ioe) {
-                throw ExceptionHelper.wrapOrThrow(ioe);
+                throw ExceptionHelper.convertToRuntimeException(ioe);
             }
             imageDictionary.put(pdfImage.name(), fixedRef);
             return fixedRef;
@@ -3085,7 +3085,7 @@ public class PdfWriter extends DocWriter implements
             object = addToBody(icc);
         }
         catch(IOException ioe) {
-            throw ExceptionHelper.wrapOrThrow(ioe);
+            throw ExceptionHelper.convertToRuntimeException(ioe);
         }
         return object.getIndirectReference();
     }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/RadioCheckField.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/RadioCheckField.java
@@ -49,7 +49,7 @@ package com.lowagie.text.pdf;
 import java.io.IOException;
 
 import com.lowagie.text.DocumentException;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import com.lowagie.text.Rectangle;
 
 /**
@@ -167,7 +167,7 @@ public class RadioCheckField extends BaseField {
             setFont(BaseFont.createFont(BaseFont.ZAPFDINGBATS, BaseFont.WINANSI, false));
         }
         catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
     

--- a/openpdf/src/main/java/com/lowagie/text/pdf/TrueTypeFont.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/TrueTypeFont.java
@@ -59,7 +59,7 @@ import com.lowagie.text.error_messages.MessageLocalization;
 
 import com.lowagie.text.Document;
 import com.lowagie.text.DocumentException;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 
 /** Reads a Truetype font
  *
@@ -696,7 +696,7 @@ class TrueTypeFont extends BaseFont {
             return new String(buf, WINANSI);
         }
         catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
     

--- a/openpdf/src/main/java/com/lowagie/text/pdf/TrueTypeFontSubSet.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/TrueTypeFontSubSet.java
@@ -56,7 +56,7 @@ import java.util.HashMap;
 import com.lowagie.text.error_messages.MessageLocalization;
 
 import com.lowagie.text.DocumentException;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 
 /** Subsets a True Type font by removing the unneeded glyphs from
  * the font.
@@ -389,7 +389,7 @@ class TrueTypeFontSubSet {
             return new String(buf, BaseFont.WINANSI);
         }
         catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
     }
     

--- a/openpdf/src/main/java/com/lowagie/text/pdf/codec/wmf/MetaFont.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/codec/wmf/MetaFont.java
@@ -53,7 +53,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.Locale;
 
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import com.lowagie.text.Font;
 import com.lowagie.text.FontFactory;
 import com.lowagie.text.pdf.BaseFont;
@@ -189,7 +189,7 @@ public class MetaFont extends MetaObject {
             font = BaseFont.createFont(fontName, "Cp1252", false);
         }
         catch (Exception e) {
-            throw ExceptionHelper.wrapOrThrow(e);
+            throw ExceptionHelper.convertToRuntimeException(e);
         }
         
         return font;

--- a/openpdf/src/main/java/com/lowagie/text/pdf/events/FieldPositioningEvents.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/events/FieldPositioningEvents.java
@@ -52,7 +52,7 @@ import com.lowagie.text.error_messages.MessageLocalization;
 
 import com.lowagie.text.Document;
 import com.lowagie.text.DocumentException;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import com.lowagie.text.Rectangle;
 import com.lowagie.text.pdf.PdfContentByte;
 import com.lowagie.text.pdf.PdfFormField;
@@ -159,7 +159,7 @@ public class FieldPositioningEvents extends PdfPageEventHelper implements PdfPCe
 			try {
 				field = tf.getTextField();
 			} catch (Exception e) {
-				throw ExceptionHelper.wrapOrThrow(e);
+				throw ExceptionHelper.convertToRuntimeException(e);
 			}
 		}
 		else {

--- a/openpdf/src/main/java/com/lowagie/text/pdf/hyphenation/SimplePatternParser.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/hyphenation/SimplePatternParser.java
@@ -50,7 +50,7 @@
 
 package com.lowagie.text.pdf.hyphenation;
 
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import com.lowagie.text.xml.simpleparser.SimpleXMLDocHandler;
 import com.lowagie.text.xml.simpleparser.SimpleXMLParser;
 
@@ -97,7 +97,7 @@ public class SimplePatternParser implements SimpleXMLDocHandler,
 		try {
 			SimpleXMLParser.parse(this, stream);
 		} catch (IOException e) {
-			throw ExceptionHelper.wrapOrThrow(e);
+			throw ExceptionHelper.convertToRuntimeException(e);
 		} finally {
 			try {
 				stream.close();

--- a/openpdf/src/main/java/com/lowagie/text/pdf/internal/PdfAnnotationsImp.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/internal/PdfAnnotationsImp.java
@@ -55,7 +55,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 
 import com.lowagie.text.Annotation;
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import com.lowagie.text.Rectangle;
 import com.lowagie.text.pdf.PdfAcroForm;
 import com.lowagie.text.pdf.PdfAction;
@@ -206,7 +206,7 @@ public class PdfAnnotationsImp {
                     writer.addToBody(dic, dic.getIndirectReference());
                 }
                 catch (IOException e) {
-                    throw ExceptionHelper.wrapOrThrow(e);
+                    throw ExceptionHelper.convertToRuntimeException(e);
                 }
             }
         }

--- a/openpdf/src/main/java/com/lowagie/text/pdf/parser/PdfContentStreamHandler.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/parser/PdfContentStreamHandler.java
@@ -52,7 +52,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Stack;
 
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import com.lowagie.text.error_messages.MessageLocalization;
 import com.lowagie.text.pdf.CMapAwareDocumentFont;
 import com.lowagie.text.pdf.PRIndirectReference;
@@ -817,7 +817,7 @@ public class PdfContentStreamHandler {
 					try {
 						data = getContentBytesFromPdfObject(stream);
 					} catch (IOException ex) {
-						throw ExceptionHelper.wrapOrThrow(ex);
+						throw ExceptionHelper.convertToRuntimeException(ex);
 					}
 					new PushGraphicsState().invoke(operands, handler, resources);			
 					processContent(data, resources2);
@@ -835,7 +835,7 @@ public class PdfContentStreamHandler {
 					invokeOperator(operator, operands, resources);
 				}
 			} catch (Exception e) {
-				throw ExceptionHelper.wrapOrThrow(e);
+				throw ExceptionHelper.convertToRuntimeException(e);
 			}
 		}
 

--- a/openpdf/src/main/java/com/lowagie/text/pdf/parser/PdfTextExtractor.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/parser/PdfTextExtractor.java
@@ -48,7 +48,7 @@
  */
 package com.lowagie.text.pdf.parser;
 
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import com.lowagie.text.pdf.PRIndirectReference;
 import com.lowagie.text.pdf.PRStream;
 import com.lowagie.text.pdf.PRTokeniser;
@@ -251,7 +251,7 @@ public class PdfTextExtractor {
 				handler.invokeOperator(operator, operands, resources);
 			}
 		} catch (Exception e) {
-			throw ExceptionHelper.wrapOrThrow(e);
+			throw ExceptionHelper.convertToRuntimeException(e);
 		}
 		handler.popContext();
 	}

--- a/openpdf/src/main/java/com/lowagie/text/xml/xmp/XmpReader.java
+++ b/openpdf/src/main/java/com/lowagie/text/xml/xmp/XmpReader.java
@@ -64,7 +64,7 @@ import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
-import io.reactivex.internal.util.ExceptionHelper;
+import com.lowagie.text.ExceptionHelper;
 import com.lowagie.text.xml.XmlDomWriter;
 
 /**
@@ -98,7 +98,7 @@ public class XmpReader {
 	        ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
 	        domDocument = db.parse(bais);
 		} catch (ParserConfigurationException e) {
-			throw ExceptionHelper.wrapOrThrow(e);
+			throw ExceptionHelper.convertToRuntimeException(e);
 		}
 	}
 	


### PR DESCRIPTION
The `ExceptionHelper` class is still missing a license header. Where do I get the correct header? Headers of other classes contains stuff like `itext` and `Bruno Lowagie` so I'm not sure if is correct to just copy?